### PR TITLE
Docs: Add missing pause menu to doc navigation

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -32,6 +32,7 @@ nav = [
         "plugins/npc.md",
         "plugins/particle.md",
         "plugins/pathfinding.md",
+        "plugins/pause_menu.md",
         "plugins/physics.md",
         "plugins/player.md",
         "plugins/portal.md",


### PR DESCRIPTION
## Summary

This PR adds the pause menu documentation to the sidebar in Zensical

## Changes

- Add PauseMenuPlugin documentation to Zensical

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Tested locally

