### PR TITLE
Chore: docs workflow only runs on docs or zensical change

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "docs/**"
+      - "zensical.toml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "zensical.toml"
 
 permissions:
   contents: read
@@ -16,10 +23,15 @@ concurrency:
 
 jobs:
   deploy:
+    runs-on: ubuntu-latest
+
+    # Only deploy on push
+    if: github.event_name == 'push'
+
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,7 +39,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install dependencies
         run: pip install zensical
@@ -41,7 +53,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: 'site'
+          path: "site"
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary

This PR makes sure we only build/deploy documentation if there are changes in zensical.toml or the docs folder

## Changes

- Update docs workflow to only deploy on docs/ or zensical.toml changes

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Tested locally

