### PR TITLE
Fix: Rename reveal_npcs to start_appear_animation

### DIFF
--- a/docs/plugins/npc.md
+++ b/docs/plugins/npc.md
@@ -352,7 +352,7 @@ npc_plugin.show_npcs(["guard", "captain", "merchant"])
 - Makes sprite.visible = True
 - Starts appear animation for AnimatedNPCs
 - Adds NPC to wall collision list
-- Used by `reveal_npcs` action
+- Used by `start_appear_animation` action
 
 ### State Queries
 
@@ -959,11 +959,11 @@ Move one or more NPCs to a waypoint using pathfinding.
 - Uses A* pathfinding to avoid obstacles
 - Publishes `NPCMovementCompleteEvent` when done
 
-### RevealNPCsAction
+### StartAppearAnimationAction
 
-Make hidden NPCs visible with appear animation.
+Start the appear animation for one or more NPCs.
 
-**Type:** `reveal_npcs`
+**Type:** `start_appear_animation`
 
 **Parameters:**
 
@@ -973,7 +973,7 @@ Make hidden NPCs visible with appear animation.
 
 ```json
 {
-    "type": "reveal_npcs",
+    "type": "start_appear_animation",
     "npcs": ["spirit", "guardian"]
 }
 ```
@@ -1102,7 +1102,7 @@ Wait for multiple NPCs to complete appear animations.
 
 ```json
 [
-    {"type": "reveal_npcs", "npcs": ["spirit", "guardian"]},
+    {"type": "start_appear_animation", "npcs": ["spirit", "guardian"]},
     {"type": "wait_npcs_appear", "npcs": ["spirit", "guardian"]},
     {"type": "dialog", "speaker": "Spirit", "text": ["We have arrived!"]}
 ]
@@ -1290,7 +1290,7 @@ if nearby:
         },
         "actions": [
             {"type": "play_sfx", "file": "magic.wav"},
-            {"type": "reveal_npcs", "npcs": ["spirit_1", "spirit_2", "spirit_3"]},
+            {"type": "start_appear_animation", "npcs": ["spirit_1", "spirit_2", "spirit_3"]},
             {"type": "wait_npcs_appear", "npcs": ["spirit_1", "spirit_2", "spirit_3"]},
             {"type": "dialog", "speaker": "Spirit", "text": ["You have summoned us!"]}
         ]

--- a/docs/plugins/scene.md
+++ b/docs/plugins/scene.md
@@ -796,7 +796,7 @@ context.scene_plugin.request_transition("castle.tmx", "main_entrance")
             {"type": "play_music", "file": "forest_ambience.ogg"},
             {"type": "dialog", "speaker": "Narrator", "text": ["The forest is dark and mysterious..."]},
             {"type": "wait_for_dialog_close"},
-            {"type": "reveal_npcs", "npcs": ["forest_spirit"]}
+            {"type": "start_appear_animation", "npcs": ["forest_spirit"]}
         ]
     }
 }

--- a/docs/plugins/script.md
+++ b/docs/plugins/script.md
@@ -402,7 +402,7 @@ Published when a script completes execution.
       "script": "intro_cutscene"
     },
     "actions": [
-      {"type": "reveal_npcs", "npcs": ["guard"]}
+      {"type": "start_appear_animation", "npcs": ["guard"]}
     ]
   }
 }
@@ -509,7 +509,7 @@ Check if a specific script has fully completed all its actions.
     "run_once": true,
     "actions": [
       {"type": "play_sfx", "file": "magic.wav"},
-      {"type": "reveal_npcs", "npcs": ["spirit"]},
+      {"type": "start_appear_animation", "npcs": ["spirit"]},
       {"type": "wait_npcs_appear", "npcs": ["spirit"]}
     ]
   },

--- a/docs/scripting/actions.md
+++ b/docs/scripting/actions.md
@@ -166,9 +166,9 @@ Move NPC(s) to a waypoint using pathfinding.
 - Dynamic positioning
 - Timed sequences
 
-### reveal_npcs
+### start_appear_animation
 
-Make NPCs visible with appear animation.
+Start the appear animation for one or more NPCs.
 
 **Parameters:**
 
@@ -178,7 +178,7 @@ Make NPCs visible with appear animation.
 
 ```json
 {
-  "type": "reveal_npcs",
+  "type": "start_appear_animation",
   "npcs": ["guard", "captain", "merchant"]
 }
 ```
@@ -757,7 +757,7 @@ Pause until NPCs finish their appear animation.
 {
   "actions": [
     {
-      "type": "reveal_npcs",
+      "type": "start_appear_animation",
       "npcs": ["villain"]
     },
     {
@@ -889,7 +889,7 @@ Actions execute in order. Use wait actions to control timing:
     },
     // 3. Reveal NPC
     {
-      "type": "reveal_npcs",
+      "type": "start_appear_animation",
       "npcs": ["spirit"]
     },
     // 4. Wait for appear animation
@@ -1077,7 +1077,7 @@ Actions execute in order. Use wait actions to control timing:
       "file": "ominous.ogg"
     },
     {
-      "type": "reveal_npcs",
+      "type": "start_appear_animation",
       "npcs": ["villain"]
     },
     {

--- a/docs/scripting/advanced.md
+++ b/docs/scripting/advanced.md
@@ -43,7 +43,7 @@ Chain multiple scripts using `script_complete` to create multi-part cutscenes.
         "npc": "elder"
       },
       {
-        "type": "reveal_npcs",
+        "type": "start_appear_animation",
         "npcs": ["spirit"]
       }
     ]
@@ -111,7 +111,7 @@ Create branching paths based on player actions and game state.
         "text": ["You have the royal seal! Enter."]
       },
       {
-        "type": "reveal_npcs",
+        "type": "start_appear_animation",
         "npcs": ["king"]
       }
     ]
@@ -339,7 +339,7 @@ Create dramatic timing with coordinated movement, dialog, and effects.
         "file": "ominous.ogg"
       },
       {
-        "type": "reveal_npcs",
+        "type": "start_appear_animation",
         "npcs": ["villain"]
       },
       {
@@ -364,7 +364,7 @@ Create dramatic timing with coordinated movement, dialog, and effects.
         "type": "wait_for_dialog_close"
       },
       {
-        "type": "reveal_npcs",
+        "type": "start_appear_animation",
         "npcs": ["minion_1", "minion_2"]
       }
     ]
@@ -405,7 +405,7 @@ Coordinate multiple NPCs with precise timing.
         "type": "wait_for_dialog_close"
       },
       {
-        "type": "reveal_npcs",
+        "type": "start_appear_animation",
         "npcs": ["guard", "merchant", "healer"]
       },
       {
@@ -592,7 +592,7 @@ Reveal NPCs based on quest progress or conditions.
         "type": "wait_for_dialog_close"
       },
       {
-        "type": "reveal_npcs",
+        "type": "start_appear_animation",
         "npcs": ["merchant_1", "merchant_2", "merchant_3", "buyer_1", "buyer_2"]
       }
     ]

--- a/docs/scripting/basics.md
+++ b/docs/scripting/basics.md
@@ -205,7 +205,7 @@ Break long action sequences into multiple scripts using `script_complete`:
     {"type": "dialog", ...},
     {"type": "move_npc", ...},
     {"type": "play_music", ...},
-    {"type": "reveal_npcs", ...}
+    {"type": "start_appear_animation", ...}
     // 20 more actions...
   ]
 }

--- a/docs/scripting/conditions.md
+++ b/docs/scripting/conditions.md
@@ -475,7 +475,7 @@ Create branching paths based on player actions:
         "text": ["You have the royal seal! Enter."]
       },
       {
-        "type": "reveal_npcs",
+        "type": "start_appear_animation",
         "npcs": ["king"]
       }
     ]

--- a/docs/scripting/events.md
+++ b/docs/scripting/events.md
@@ -709,7 +709,7 @@ Triggered when a new scene/map finishes loading.
     "run_once": true,
     "actions": [
       {
-        "type": "reveal_npcs",
+        "type": "start_appear_animation",
         "npcs": ["king", "advisor"]
       },
       {
@@ -742,7 +742,7 @@ Triggered when another script finishes executing.
     },
     "actions": [
       {
-        "type": "reveal_npcs",
+        "type": "start_appear_animation",
         "npcs": ["guard", "captain"]
       }
     ]

--- a/docs/scripting/examples.md
+++ b/docs/scripting/examples.md
@@ -111,7 +111,7 @@ Coordinating multiple NPCs with movement and dialog.
         "type": "wait_for_dialog_close"
       },
       {
-        "type": "reveal_npcs",
+        "type": "start_appear_animation",
         "npcs": ["guard", "merchant"]
       },
       {
@@ -230,7 +230,7 @@ Dramatic boss appearance with music and effects.
         "interactive_object": "altar"
       },
       {
-        "type": "reveal_npcs",
+        "type": "start_appear_animation",
         "npcs": ["boss"]
       },
       {
@@ -487,7 +487,7 @@ Different responses based on whether player has required item.
         "npc": "guard"
       },
       {
-        "type": "reveal_npcs",
+        "type": "start_appear_animation",
         "npcs": ["king"]
       }
     ]
@@ -672,7 +672,7 @@ Complex cutscene with multiple stages.
         "type": "wait_for_dialog_close"
       },
       {
-        "type": "reveal_npcs",
+        "type": "start_appear_animation",
         "npcs": ["dark_knight_1", "dark_knight_2"]
       }
     ]
@@ -712,7 +712,7 @@ Time-gated event that unlocks new NPCs.
         "type": "wait_for_dialog_close"
       },
       {
-        "type": "reveal_npcs",
+        "type": "start_appear_animation",
         "npcs": ["merchant_1", "merchant_2", "merchant_3"]
       },
       {

--- a/src/pedre/plugins/npc/__init__.py
+++ b/src/pedre/plugins/npc/__init__.py
@@ -11,7 +11,7 @@ The NPC plugin consists of:
 - AnimatedNPC: Animated sprite class for NPCs with special animations
 
 Actions (registered via INSTALLED_ACTIONS):
-- AdvanceDialogAction, MoveNPCAction, RevealNPCsAction, SetCurrentNPCAction
+- AdvanceDialogAction, MoveNPCAction, StartAppearAnimationAction, SetCurrentNPCAction
 - SetDialogLevelAction, StartDisappearAnimationAction, WaitForNPCMovementAction
 - WaitForNPCsAppearAction, WaitForNPCsDisappearAction
 

--- a/src/pedre/plugins/npc/actions.py
+++ b/src/pedre/plugins/npc/actions.py
@@ -100,9 +100,9 @@ class MoveNPCAction(Action):
         return cls(npc_names=npcs, waypoint=waypoint)
 
 
-@ActionRegistry.register("reveal_npcs")
-class RevealNPCsAction(Action):
-    """Reveal hidden NPCs with visual effects.
+@ActionRegistry.register("start_appear_animation")
+class StartAppearAnimationAction(Action):
+    """Start the appear animation for one or more NPCs.
 
     This action makes NPCs visible that have their sprite.visible property set to False.
     Hidden NPCs are not rendered and cannot be interacted with by the player. When revealed,
@@ -113,13 +113,13 @@ class RevealNPCsAction(Action):
 
     Example usage:
         {
-            "type": "reveal_npcs",
+            "type": "start_appear_animation",
             "npcs": ["martin", "yema", "romi"]
         }
     """
 
     def __init__(self, npc_names: list[str]) -> None:
-        """Initialize NPC reveal action.
+        """Initialize NPC appear animation action.
 
         Args:
             npc_names: List of NPC names to reveal.
@@ -133,7 +133,7 @@ class RevealNPCsAction(Action):
             npc_plugin = context.npc_plugin
             npc_plugin.show_npcs(self.npc_names)
             self.executed = True
-            logger.debug("RevealNPCsAction: Revealed NPCs %s", self.npc_names)
+            logger.debug("StartAppearAnimationAction: Revealed NPCs %s", self.npc_names)
 
         return True
 
@@ -143,7 +143,7 @@ class RevealNPCsAction(Action):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Self:
-        """Create RevealNPCsAction from a dictionary."""
+        """Create StartAppearAnimationAction from a dictionary."""
         return cls(npc_names=data.get("npcs", []))
 
 
@@ -387,19 +387,19 @@ class WaitForNPCsAppearAction(WaitForConditionAction):
 
     This action pauses script execution until all specified AnimatedNPCs finish
     their appear animation. AnimatedNPCs play a special appear animation when
-    they're revealed (see RevealNPCsAction), and this action ensures that animation
+    they're revealed (see StartAppearAnimationAction), and this action ensures that animation
     completes before proceeding.
 
     Only AnimatedNPC sprites have appear animations. Regular NPC sprites will be
     considered complete immediately. The action waits for all NPCs in the list
     to finish appearing.
 
-    Commonly used after RevealNPCsAction to ensure NPCs have fully materialized
+    Commonly used after StartAppearAnimationAction to ensure NPCs have fully materialized
     before starting dialog or other interactions.
 
     Example usage in a reveal sequence:
         [
-            {"type": "reveal_npcs", "npcs": ["martin", "yema"]},
+            {"type": "start_appear_animation", "npcs": ["martin", "yema"]},
             {"type": "wait_npcs_appear", "npcs": ["martin", "yema"]},
             {"type": "dialog", "speaker": "martin", "text": ["We're here!"]}
         ]

--- a/src/pedre/plugins/npc/sprites.py
+++ b/src/pedre/plugins/npc/sprites.py
@@ -534,7 +534,7 @@ class AnimatedNPC(AnimatedSprite):
         """Start the appear animation (invisible to visible).
 
         Triggers the appear animation which transitions the sprite from invisible to visible.
-        This is typically used when revealing NPCs through scripts (RevealNPCsAction).
+        This is typically used when revealing NPCs through scripts (StartAppearAnimationAction).
 
         The animation plays once and sets appear_complete = True when finished. The sprite
         then transitions to idle animation automatically.

--- a/src/pedre/plugins/particle/plugin.py
+++ b/src/pedre/plugins/particle/plugin.py
@@ -70,8 +70,6 @@ class ParticlePlugin(ParticleBasePlugin):
 
     Integration with actions:
     - EmitParticlesAction can trigger effects from scripts
-    - RevealNPCsAction emits gold burst particles when NPCs appear
-    - Various game plugins emit particles for player feedback
 
     Attributes:
         particles: List of currently active particles.
@@ -282,7 +280,6 @@ class ParticlePlugin(ParticleBasePlugin):
         larger and live longer than sparkles, making the effect more prominent.
 
         Common uses:
-        - NPC reveals (RevealNPCsAction uses gold burst)
         - Quest completion moments
         - Major event triggers
         - Dramatic reveals and discoveries

--- a/tests/plugins/npc/test_npc_actions.py
+++ b/tests/plugins/npc/test_npc_actions.py
@@ -8,9 +8,9 @@ from unittest.mock import MagicMock
 from pedre.plugins.npc.actions import (
     AdvanceDialogAction,
     MoveNPCAction,
-    RevealNPCsAction,
     SetCurrentNPCAction,
     SetDialogLevelAction,
+    StartAppearAnimationAction,
     StartDisappearAnimationAction,
     WaitForNPCMovementAction,
     WaitForNPCsAppearAction,
@@ -132,8 +132,8 @@ class TestMoveNPCAction(unittest.TestCase):
         assert action.waypoint == ""
 
 
-class TestRevealNPCsAction(unittest.TestCase):
-    """Test Suite for RevealNPCsAction."""
+class TestStartAppearAnimationAction(unittest.TestCase):
+    """Test Suite for StartAppearAnimationAction."""
 
     def setUp(self) -> None:
         """Set up the test context."""
@@ -142,14 +142,14 @@ class TestRevealNPCsAction(unittest.TestCase):
         self.mock_context.npc_plugin = self.mock_npc_plugin
 
     def test_initialization(self) -> None:
-        """Test proper initialization of RevealNPCsAction."""
-        action = RevealNPCsAction(npc_names=["martin", "yema"])
+        """Test proper initialization of StartAppearAnimationAction."""
+        action = StartAppearAnimationAction(npc_names=["martin", "yema"])
         assert action.npc_names == ["martin", "yema"]
         assert not action.executed
 
     def test_execute(self) -> None:
-        """Test executing reveal action."""
-        action = RevealNPCsAction(npc_names=["martin", "yema"])
+        """Test executing appear animation action."""
+        action = StartAppearAnimationAction(npc_names=["martin", "yema"])
 
         # Execute action
         result = action.execute(self.mock_context)
@@ -162,8 +162,8 @@ class TestRevealNPCsAction(unittest.TestCase):
         self.mock_npc_plugin.show_npcs.assert_called_once_with(["martin", "yema"])
 
     def test_execute_idempotent(self) -> None:
-        """Test that executing multiple times doesn't repeat the reveal."""
-        action = RevealNPCsAction(npc_names=["martin"])
+        """Test that executing multiple times doesn't repeat the appear animation."""
+        action = StartAppearAnimationAction(npc_names=["martin"])
 
         # Execute twice
         action.execute(self.mock_context)
@@ -174,7 +174,7 @@ class TestRevealNPCsAction(unittest.TestCase):
 
     def test_reset(self) -> None:
         """Test resetting the action."""
-        action = RevealNPCsAction(npc_names=["martin"])
+        action = StartAppearAnimationAction(npc_names=["martin"])
         action.executed = True
 
         action.reset()
@@ -185,7 +185,7 @@ class TestRevealNPCsAction(unittest.TestCase):
         """Test creating action from dictionary."""
         data = {"npcs": ["martin", "yema", "romi"]}
 
-        action = RevealNPCsAction.from_dict(data)
+        action = StartAppearAnimationAction.from_dict(data)
 
         assert action.npc_names == ["martin", "yema", "romi"]
 
@@ -193,7 +193,7 @@ class TestRevealNPCsAction(unittest.TestCase):
         """Test creating action from dictionary with missing fields."""
         data = {}
 
-        action = RevealNPCsAction.from_dict(data)
+        action = StartAppearAnimationAction.from_dict(data)
 
         assert action.npc_names == []
 


### PR DESCRIPTION
## Summary

This PR renames `reveal_npcs` to `start_appear_animation` to match  its `start_disappear_animation` counterpart


## Changes

- Rename `reveal_npcs` to `start_appear_animation`

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Tested locally

