### PR TITLE
Fix: Rename wait_inventory_access to wait_for_inventory_access

### DIFF
--- a/docs/plugins/inventory.md
+++ b/docs/plugins/inventory.md
@@ -754,7 +754,7 @@ Consume an item from the player's inventory.
 
 Wait for inventory to be accessed.
 
-**Type:** `wait_inventory_access`
+**Type:** `wait_for_inventory_access`
 
 **Parameters:** None
 
@@ -764,7 +764,7 @@ Wait for inventory to be accessed.
 [
     {"type": "dialog", "speaker": "martin", "text": ["Check your inventory!"]},
     {"type": "wait_for_dialog_close"},
-    {"type": "wait_inventory_access"},
+    {"type": "wait_for_inventory_access"},
     {"type": "dialog", "speaker": "martin", "text": ["Great job!"]}
 ]
 ```
@@ -996,7 +996,7 @@ INSTALLED_PLUGINS = [
             {"type": "acquire_item", "item_id": "beach_photo"},
             {"type": "dialog", "speaker": "Martin", "text": ["Check your inventory (press I)!"]},
             {"type": "wait_for_dialog_close"},
-            {"type": "wait_inventory_access"},
+            {"type": "wait_for_inventory_access"},
             {"type": "dialog", "speaker": "Martin", "text": ["Great! You can view the photo by pressing V."]},
             {"type": "wait_for_dialog_close"},
             {"type": "advance_dialog", "npc": "martin"}

--- a/src/pedre/plugins/inventory/actions.py
+++ b/src/pedre/plugins/inventory/actions.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@ActionRegistry.register("wait_inventory_access")
+@ActionRegistry.register("wait_for_inventory_access")
 class WaitForInventoryAccessAction(WaitForConditionAction):
     """Wait for inventory to be accessed.
 
@@ -33,7 +33,7 @@ class WaitForInventoryAccessAction(WaitForConditionAction):
         [
             {"type": "dialog", "speaker": "martin", "text": ["Check your inventory!"]},
             {"type": "wait_for_dialog_close"},
-            {"type": "wait_inventory_access"},
+            {"type": "wait_for_inventory_access"},
             {"type": "dialog", "speaker": "martin", "text": ["Great job!"]}
         ]
     """


### PR DESCRIPTION
## Summary

This PR renames `wait_inventory_access` to `wait_for_inventory_access` to match the rest of the wait actions.

## Changes

- Rename `wait_inventory_access` to `wait_for_inventory_access`
- Documentation changes

## Testing

- [x] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Tested locally

